### PR TITLE
fix: ESM compatibility — add .js extensions and default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FHIRSchema
 
-[![CI](https://github.com/fhir-schema/fhirschema-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/fhir-schema/fhirschema-ts/actions/workflows/ci.yml)
-[![Type Check](https://github.com/fhir-schema/fhirschema-ts/actions/workflows/typecheck.yml/badge.svg)](https://github.com/fhir-schema/fhirschema-ts/actions/workflows/typecheck.yml)
+[![CI](https://github.com/atomic-ehr/fhirschema/actions/workflows/ci.yml/badge.svg)](https://github.com/atomic-ehr/fhirschema/actions/workflows/ci.yml)
+[![Type Check](https://github.com/atomic-ehr/fhirschema/actions/workflows/typecheck.yml/badge.svg)](https://github.com/atomic-ehr/fhirschema/actions/workflows/typecheck.yml)
 
 TypeScript implementation of FHIRSchema converter and validator.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@atomic-ehr/fhirschema",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/src/validator/cardinality.ts
+++ b/src/validator/cardinality.ts
@@ -1,6 +1,6 @@
 import type { OperationOutcome, OperationOutcomeIssue } from '../converter/types';
 import type { FHIRSchemaElement } from '../types';
-import * as fp from './fieldPath';
+import * as fp from './fieldPath.js';
 
 const validate = (
   data: unknown,

--- a/src/validator/complex.ts
+++ b/src/validator/complex.ts
@@ -1,8 +1,8 @@
 import type { OperationOutcome, OperationOutcomeIssue } from '../converter/types';
 import type { FHIRSchema } from '../types';
-import * as cardinality from './cardinality';
-import * as fp from './fieldPath';
-import * as primitive from './primitive';
+import * as cardinality from './cardinality.js';
+import * as fp from './fieldPath.js';
+import * as primitive from './primitive.js';
 
 const validate = (
   data: Record<string, unknown>,

--- a/src/validator/primitive.ts
+++ b/src/validator/primitive.ts
@@ -1,6 +1,6 @@
 import type { OperationOutcome, OperationOutcomeIssue } from '../converter/types';
 import type { FHIRSchema } from '../types';
-import * as fp from './fieldPath';
+import * as fp from './fieldPath.js';
 
 // FHIR primitive types that map to JavaScript 'string'
 const STRING_TYPES = new Set([

--- a/src/validator/resource.ts
+++ b/src/validator/resource.ts
@@ -1,10 +1,10 @@
 import type { OperationOutcome, OperationOutcomeIssue, Resource } from '../converter/types';
 import type { DiscriminatorType, FHIRSchema, FHIRSchemaElement } from '../types';
-import * as cardinality from './cardinality';
-import * as complex from './complex';
-import * as fp from './fieldPath';
-import * as primitive from './primitive';
-import type { Deferred } from './types';
+import * as cardinality from './cardinality.js';
+import * as complex from './complex.js';
+import * as fp from './fieldPath.js';
+import * as primitive from './primitive.js';
+import type { Deferred } from './types.js';
 
 export interface ValidationOutput {
   outcome: OperationOutcome;


### PR DESCRIPTION
- Add missing `.js` extensions to `validator/` internal imports — fixes `ERR_MODULE_NOT_FOUND` under strict Node ESM resolution
- Add `"default"` condition to `exports` map — fixes `ERR_PACKAGE_PATH_NOT_EXPORTED` when consumed via CJS resolvers (e.g. `tsx`)
- Fix README CI badges to point to `atomic-ehr/fhirschema`