### PR TITLE
Unify release flow + add MIT LICENSE file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm publish --tag latest --access public
 
       - name: Create Github Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Atomic EHR Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
-# Check if version argument is provided
-if [ -z "$1" ]; then
-    echo "Error: Version number required"
+# Validate semver format
+if ! echo "$1" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    echo "❌ Error: Invalid version format"
     echo "Usage: bun run release <version>"
     echo "Example: bun run release 0.0.18"
     exit 1
 fi
+
+VERSION=$1
 
 # Check if we're on main branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -18,7 +20,12 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
     exit 1
 fi
 
-VERSION=$1
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "❌ Error: Working tree has uncommitted changes"
+    echo "Please commit or stash your changes before releasing"
+    exit 1
+fi
 
 echo "📦 Releasing version $VERSION..."
 
@@ -26,13 +33,9 @@ echo "📦 Releasing version $VERSION..."
 echo "Updating package.json..."
 npm version $VERSION --no-git-tag-version
 
-# Commit the changes (package.json and package-lock.json if it exists)
+# Commit the changes
 echo "Committing changes..."
 git add package.json
-if [ -f "package-lock.json" ]; then
-    git add package-lock.json
-    echo "Updated package-lock.json"
-fi
 git commit -m "chore: bump version to $VERSION"
 
 # Create and push tag


### PR DESCRIPTION
## Summary

Aligns this repo's release flow with the `@atomic-ehr/codegen` standard, and completes its license declaration.

### 1. Unify release flow
- **`scripts/release.sh`**: backport codegen's two guardrails — **semver-format validation** and a **clean-tree check** — so the script is now identical to the codegen release script.
- **`release.yml`**: upgrade `softprops/action-gh-release` `v2` → `v3` to match the shared standard. `actions/checkout` stays on `v6` (no downgrade).

### 2. Add MIT LICENSE file
`package.json` already declares `"license": "MIT"`, but there was **no root `LICENSE` file**. This adds it (matching `@atomic-ehr/codegen`), so the license is properly declared in the repo and published tarball.

Companion PR does the same for `fhir-canonical-manager` (which also fixes atomic-ehr/fhir-canonical-manager#19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)