### PR TITLE
docs: badge stack matching codegen (canary + npm version + CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # FHIRSchema
 
+[![npm canary](https://img.shields.io/npm/v/@atomic-ehr/fhirschema/canary.svg?label=canary)](https://www.npmjs.com/package/@atomic-ehr/fhirschema/v/canary)
+[![npm version](https://img.shields.io/npm/v/@atomic-ehr/fhirschema.svg)](https://www.npmjs.com/package/@atomic-ehr/fhirschema)
 [![CI](https://github.com/atomic-ehr/fhirschema/actions/workflows/ci.yml/badge.svg)](https://github.com/atomic-ehr/fhirschema/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/@atomic-ehr/fhirschema)](https://www.npmjs.com/package/@atomic-ehr/fhirschema)
 
 TypeScript implementation of FHIRSchema converter and validator.
 


### PR DESCRIPTION
Updates the README badges to mirror `@atomic-ehr/codegen`'s style:

- **npm canary** — `img.shields.io/npm/v/@atomic-ehr/fhirschema/canary.svg?label=canary`
- **npm version** — replaces the previous plain `npm` badge
- **CI** — unchanged, reordered below the npm badges

Before:
```
[CI] [npm]
```
After:
```
[npm canary] [npm version] [CI]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)