### PR TITLE
Converter: derive choices from the explicit type ceiling, not slice names

### DIFF
--- a/src/converter/choice-handler.ts
+++ b/src/converter/choice-handler.ts
@@ -38,9 +38,15 @@ function isChoiceTypeSlicingRoot(element: StructureDefinitionElement): boolean {
 /**
  * Collapse type slicing on choice elements ($this type discriminator) into the
  * plain choice representation: the sliced element becomes the choice declaration
- * (accumulating every variant in `choices` and keeping the slicing metadata so
- * open/closed rules survive), and each slice becomes a regular typed variant
- * element. Children of a slice are re-parented under its variant element.
+ * (keeping the slicing metadata so open/closed rules survive), and each slice
+ * becomes a regular typed variant element. Children of a slice are re-parented
+ * under its variant element.
+ *
+ * `choices` is derived only from the explicit ElementDefinition.type ceiling —
+ * never from slice names. Slices constrain types the element already allows, so
+ * for a typed root the slice set adds nothing, and for an untyped root under
+ * open rules the slices are additive documentation: emitting them as `choices`
+ * would misstate the allowed set (the inherited ceiling stays in effect).
  */
 export function collapseChoiceTypeSlicing(
   elements: StructureDefinitionElement[],
@@ -71,10 +77,8 @@ export function collapseChoiceTypeSlicing(
       const el = elements[j];
       if (el.path === rootPath && el.sliceName && el.type?.length === 1) {
         const typeName = capitalize(canonicalToName(el.type[0].code));
-        const variantName = fieldName + typeName;
         variantPath = basePath + typeName;
-        if (!choices.includes(variantName)) choices.push(variantName);
-        slicedVariants.add(variantName);
+        slicedVariants.add(fieldName + typeName);
         const { sliceName, ...sliceRest } = el;
         collapsed.push({ ...sliceRest, path: variantPath, choiceOf: fieldName });
       } else if (el.path.startsWith(`${rootPath}.`) && variantPath) {
@@ -85,7 +89,12 @@ export function collapseChoiceTypeSlicing(
       }
     }
 
-    result.push({ ...rootRest, path: basePath, choices, _choiceSlicing: slicing });
+    result.push({
+      ...rootRest,
+      path: basePath,
+      ...(choices.length > 0 ? { choices } : {}),
+      _choiceSlicing: slicing,
+    });
 
     // Explicit root types without a matching slice keep plain variant elements,
     // mirroring expandChoiceElement for unsliced choice elements.

--- a/test/unit/converter.test.ts
+++ b/test/unit/converter.test.ts
@@ -1024,12 +1024,42 @@ describe('Converter Algorithm Tests', () => {
       },
     ];
 
-    it('keeps every declared slice variant as a choice', () => {
+    it('materializes slice variants without narrowing choices for an untyped root', () => {
       const result = translate(createTestStructureDefinition(openOnsetSlicing));
 
-      expect(result.elements?.onset?.choices).toEqual(['onsetPeriod', 'onsetAge']);
+      // Open slices are additive: without an explicit type ceiling on the root,
+      // the inherited choice set stays in effect, so no `choices` is emitted.
+      expect(result.elements?.onset?.choices).toBeUndefined();
       expect(result.elements?.onsetPeriod).toMatchObject({ type: 'Period', choiceOf: 'onset' });
       expect(result.elements?.onsetAge).toMatchObject({ type: 'Age', choiceOf: 'onset' });
+    });
+
+    it('derives choices from the explicit type ceiling of a sliced root', () => {
+      const result = translate(
+        createTestStructureDefinition([
+          {
+            path: 'Test.value[x]',
+            slicing: { discriminator: [{ type: 'type', path: '$this' }], rules: 'open' },
+            type: [{ code: 'Quantity' }, { code: 'CodeableConcept' }],
+          },
+          {
+            path: 'Test.value[x]',
+            sliceName: 'valueQuantity',
+            max: '1',
+            type: [{ code: 'Quantity' }],
+          },
+        ]),
+      );
+
+      expect(result.elements?.value?.choices).toEqual(['valueQuantity', 'valueCodeableConcept']);
+      expect(result.elements?.valueQuantity).toMatchObject({
+        type: 'Quantity',
+        choiceOf: 'value',
+      });
+      expect(result.elements?.valueCodeableConcept).toMatchObject({
+        type: 'CodeableConcept',
+        choiceOf: 'value',
+      });
     });
 
     it('preserves open slicing rules and discriminator on the choice element', () => {
@@ -1061,6 +1091,38 @@ describe('Converter Algorithm Tests', () => {
       );
 
       expect(result.elements?.value?.slicing?.rules).toBe('closed');
+    });
+
+    it('emits no choices for an untyped closed-sliced root', () => {
+      // Without a type restatement on the root, `choices` stays absent even
+      // under closed rules: the materialized slice variants plus rules: closed
+      // are the signal that unlisted variants are forbidden. Consumers must
+      // intersect with the variant elements, not with `choices`.
+      const result = translate(
+        createTestStructureDefinition([
+          {
+            path: 'Test.onset[x]',
+            slicing: { discriminator: [{ type: 'type', path: '$this' }], rules: 'closed' },
+          },
+          {
+            path: 'Test.onset[x]',
+            sliceName: 'onsetPeriod',
+            max: '1',
+            type: [{ code: 'Period' }],
+          },
+          {
+            path: 'Test.onset[x]',
+            sliceName: 'onsetAge',
+            max: '1',
+            type: [{ code: 'Age' }],
+          },
+        ]),
+      );
+
+      expect(result.elements?.onset?.choices).toBeUndefined();
+      expect(result.elements?.onset?.slicing?.rules).toBe('closed');
+      expect(result.elements?.onsetPeriod).toMatchObject({ type: 'Period', choiceOf: 'onset' });
+      expect(result.elements?.onsetAge).toMatchObject({ type: 'Age', choiceOf: 'onset' });
     });
   });
 });


### PR DESCRIPTION
- Derive the choice declaration's `choices` from the explicit `ElementDefinition.type` ceiling only — never from slice names. When a profile's differential does not restate the element's `type` list, `choices` is omitted entirely.
- Slice variants are still materialized as `choiceOf` elements with their constraints; `slicing.rules` and discriminator stay on the declaration.
- New tests: untyped open-sliced root (no `choices`), typed open-sliced root (ceiling `choices` incl. unsliced variants), untyped closed-sliced root (no `choices`; `rules: closed` + variants are the prohibition signal).

Motivation: slicing a choice under `rules: open` constrains the sliced variants without restricting the choice, but merging slice names into `choices` made that indistinguishable from a genuine type restriction. Downstream consumers (atomic-ehr/codegen) falsely prohibited unsliced variants for open profiles — the KBV Basis cases reported in atomic-ehr/codegen#196.

Before (`KBV_PR_Base_Condition_Diagnosis.onset[x]`, open slicing, no type restatement):

```json
"onset": {
  "choices": ["onsetPeriod", "onsetRange", "onsetDateTime", "onsetAge"],
  "slicing": { "discriminator": [{ "type": "type", "path": "$this" }], "rules": "open" }
}
```

After:

```json
"onset": {
  "slicing": { "discriminator": [{ "type": "type", "path": "$this" }], "rules": "open" }
}
```

Consumers inherit the base ceiling (`onsetString` stays permitted). Verified end-to-end against atomic-ehr/codegen: the full codegen suite passes unchanged, and the KBV profile resolves to all five base variants with nothing prohibited.
